### PR TITLE
ci: simplify ci to only check if compilation ready

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Contexte
+_Pourquoi ce changement ? Quel problème résout-il ?_
+
+## Points d'attention
+_Zones risquées, questions pour le reviewer, trade-offs acceptés, steps de tests si non évident..._

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,53 +1,35 @@
-name: Unity CI
+name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main, develop]
   pull_request:
-    branches: [ main ]
+    branches: [main, develop]
 
 jobs:
-  build:
+  compile:
+    name: Compilation Check
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        targetPlatform: [ Android ]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
-      - name: Free disk space (before caching)
-        run: |
-          sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache/CodeQL \
-                      /usr/local/share/boost /usr/local/.ghcup || true
-
-      - name: Cache Library folder
+      - name: Cache Library
         uses: actions/cache@v4
         with:
           path: Library
-          key: Library-${{ matrix.targetPlatform }}-${{ hashFiles('**/Packages/manifest.json') }}
-          restore-keys: |
-            Library-${{ matrix.targetPlatform }}-
-            Library-
+          key: Library-${{ hashFiles('Packages/manifest.json', 'Packages/packages-lock.json', 'ProjectSettings/**') }}
+          restore-keys: Library-
 
-      - name: Build project with Unity
-        uses: game-ci/unity-builder@v4
+      - name: Check Compilation
+        uses: game-ci/unity-test-runner@v4
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          targetPlatform: ${{ matrix.targetPlatform }}
-          buildName: ${{ matrix.targetPlatform }}
-          buildsPath: build/${{ matrix.targetPlatform }}
-          unityVersion: 6000.2.1f1
-
-      - name: Upload artifacts on GitHub
-        uses: actions/upload-artifact@v4
-        with:
-          name: Build-${{ matrix.targetPlatform }}
-          path: build/${{ matrix.targetPlatform }}
-          if-no-files-found: error
+          testMode: editmode
+          customParameters: -nographics


### PR DESCRIPTION
## Contexte
Le but de la PR est de grandement simplifier la CI.  
On est conscient que l'on n'aura pas accès à des serveurs, donc l'hébergement du front n'a pas trop de sens non plus. 

Je me charge juste de faire un check pour m'assurer que l'application compile en tout temps.
